### PR TITLE
Update for Spigot 1.9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,15 +130,19 @@ repositories {
     maven {
         url "http://repo.md-5.net/content/repositories/releases/"
     }
+    // spigot repo
+    maven {
+        url "https://hub.spigotmc.org/nexus/content/repositories/public/"
+    }
 }
 
 dependencies {
-    compile group: 'org.bukkit', name: 'bukkit', version: '1.7.9-R0.2'
+    compile group: 'org.bukkit', name: 'bukkit', version: '1.9-SNAPSHOT'
     compile group: 'net.milkbowl.vault', name: 'Vault', version: '1.4.2'
     
     compile group: 'com.sk89q', name: 'worldedit', version: '5.6.3'
     compile group: 'com.sk89q', name: 'worldguard', version: '5.9'
-    
+
     compile 'fr.neatmonster:ncpcore:static'
     
     compile group: 'org.projectlombok', name: 'lombok', version: '1.14.2'

--- a/src/main/java/com/forgenz/horses/metrics/Metrics.java
+++ b/src/main/java/com/forgenz/horses/metrics/Metrics.java
@@ -332,7 +332,7 @@ public class Metrics {
         boolean onlineMode = Bukkit.getServer().getOnlineMode(); // TRUE if online mode is enabled
         String pluginVersion = description.getVersion();
         String serverVersion = Bukkit.getVersion();
-        int playersOnline = Bukkit.getServer().getOnlinePlayers().length;
+        int playersOnline = Bukkit.getServer().getOnlinePlayers().size();
 
         // END server software specific section -- all code below does not use any code outside of this class / Java
 

--- a/src/main/java/com/forgenz/horses/tasks/HorseDismissTask.java
+++ b/src/main/java/com/forgenz/horses/tasks/HorseDismissTask.java
@@ -64,7 +64,7 @@ public class HorseDismissTask extends BukkitRunnable implements ForgeCore
 	{
 		if (players == null)
 		{
-			players = Bukkit.getOnlinePlayers();
+			players = (Player[]) Bukkit.getOnlinePlayers().toArray();
 			index = 0;
 		}
 		


### PR DESCRIPTION
Spigot 1.9 removes deprecated support for old Bukkit 1.7 methods, i.e. in this case `Player[] getOnlinePlayers`. It has been changed to use `Collection<? extends Player> getOnlinePlayers()`.
